### PR TITLE
Fix PCI-DSS link

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Well...  There are a lot.  Your organization likely uses some of these, but cert
 
 * :bank: Sarbanes-Oxley Act - [SOX](https://www.congress.gov/bill/107th-congress/house-bill/3763)   
 * :euro: General Data Protection Regulation - [GDPR](https://gdpr-info.eu/)  
-* :credit_card: Payment Card Industry Data Security Standard - [PCI-DSS](https://www.congress.gov/bill/107th-congress/house-bill/3763)  
+* :credit_card: Payment Card Industry Data Security Standard - [PCI-DSS](https://www.pcisecuritystandards.org/)  
 * :statue_of_liberty: Federal Information Security Modernization Act - [FISMA](https://www.cisa.gov/federal-information-security-modernization-act)  
 * :hospital: Health Insurance Portability and Accountability Act - [HIPAA](https://www.hhs.gov/hipaa/index.html)  
 * :oncoming_police_car: Security and Privacy Controls for Information Systems and Organizations - [NIST SP 800-53](https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final)


### PR DESCRIPTION
PCI was pointed to HB3763. This PR updates to point to the PCI website