### PR TITLE
Risk & framework section updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,13 @@ Well...  There are a lot.  Your organization likely uses some of these, but cert
 * :bank: Sarbanes-Oxley Act - [SOX](https://www.congress.gov/bill/107th-congress/house-bill/3763)   
 * :euro: General Data Protection Regulation - [GDPR](https://gdpr-info.eu/)  
 * :credit_card: Payment Card Industry Data Security Standard - [PCI-DSS](https://www.pcisecuritystandards.org/)  
-* :statue_of_liberty: Federal Information Security Modernization Act - [FISMA](https://www.cisa.gov/federal-information-security-modernization-act)  
 * :hospital: Health Insurance Portability and Accountability Act - [HIPAA](https://www.hhs.gov/hipaa/index.html)  
-* :oncoming_police_car: Security and Privacy Controls for Information Systems and Organizations - [NIST SP 800-53](https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final)
 * :white_flag: International Organisation for Standardization's Information Security Management Standard - [ISO 27001](https://www.iso.org/isoiec-27001-information-security.html)
-* :computer: American Institute of CPAs - [SOC2](https://www.aicpa.org/interestareas/frc/assuranceadvisoryservices/aicpasoc2report.html)
+* :computer: Systems and Organization Controls for Service Organizations: Trust Services Criteria - [SOC2](https://www.aicpa.org/interestareas/frc/assuranceadvisoryservices/aicpasoc2report.html)
+* ☁️ Federal Risk and Authorization Management Program - [FedRAMP](https://www.fedramp.gov/)
+* :statue_of_liberty: Federal Information Security Modernization Act - [FISMA](https://www.cisa.gov/federal-information-security-modernization-act)
+* :oncoming_police_car: Security and Privacy Controls for Information Systems and Organizations - [NIST SP 800-53 Rev. 5](https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final)
+* 🗄️ Protecting Controlled Unclassified Information in Nonfederal Systems and Organizations - [NIST SP 800-171 Rev. 2](https://csrc.nist.gov/publications/detail/sp/800-171/rev-2/final)   
 
 Added to that, each country would have specific cybersecurity regulations and standards companies would have to comply with. They could be specific to certain industries (critical infrastructures or financial services) or applicable to every company. As our planet is made of a lot of countries, we won't list the specifics here and as is often the case, US standards are picked up in most of the world anyway!
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ A robust risk management program would also include some quantitative features t
 
 #### NIST 800-39
 
+### Risk Management Tools & Packages
+
+#### Netflix's riskquant
+
+[riskquant](https://github.com/Netflix-Skunkworks/riskquant) is a python library used for risk quantification. It can be used to do cool things like calculate annualized loss and generate loss exceedence curve charts. 
+
+You can use it to assess individual risks or even build automation to run calculations and build charts for all risks where data are available. For example, you can set up a GitHub Action to pull risks from your GRC tool, get the data to run the calculations, and put the results back into your GRC tool.
+
 ## :gun: Audit & Compliance
 
 Once you know what your direction is and you know what to focus on, how do you know you're on track? There's two ways:


### PR DESCRIPTION
This PR:

1. Add a tools & packages sub-section to the risk management section. For some early content, added Netflix's riskquant
2. Adds FedRAMP and 800-171 to the frameworks section, batches the public sector stuff at the bottom, and renames AICPA to SOC (so the framework is listed over the accrediting body)