### PR TITLE
Update URL and reference to 27005 2018 to 2022

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ The Committee of Sponsoring Organizations of the Treadway Commission [(COSO)](ht
 
 #### International Organization for Standardization (ISO)
 
-[ISO/IEC 27005:2018
-Information technology – Security techniques – Information security risk management](https://www.iso.org/standard/75281.html) provides guidelines to managing _information security risks_ faced by organizations. The application of these guidelines can be applied to an Information Security Management System (ISMS) specified in ISO/IEC 27001 and ISO/IEC 27002.
+[ISO/IEC 27005:2022
+Information security, cybersecurity and privacy protection — Guidance on managing information security risks](https://www.iso.org/standard/80585.html) provides guidelines to managing _information security risks_ faced by organizations. The application of these guidelines can be applied to an Information Security Management System (ISMS) specified in ISO/IEC 27001 and ISO/IEC 27002.
 
 A technical committee named[ISO/IEC JTC 1/SC 27](https://www.iso.org/committee/45306.html) focus on the development of standards for the protection of information and ICT.
 


### PR DESCRIPTION
But of course this is going to be superseded by 2023 I think in a couple years depending on when organizations are certified. But, suggesting to update nevertheless! Also this is literally my first pull request ever so sorry there are a few diffs where it appears like I changed something but I didn’t oops. Just changed lines 91-92. Hope to make some more suggestions later :)